### PR TITLE
feat: soft delete de pedidos de productos y fix filtro pendientes

### DIFF
--- a/db/productOrder/deleteProductOrder.go
+++ b/db/productOrder/deleteProductOrder.go
@@ -1,0 +1,12 @@
+package db
+
+import (
+	"viandasApp/db"
+	"viandasApp/models"
+)
+
+func DeleteProductOrder(id int) (bool, error) {
+	dbc := db.GetDB()
+	err := dbc.Model(&models.ProductOrder{}).Where("id = ?", id).Update("status", "deleted").Error
+	return err == nil, err
+}

--- a/db/productOrder/getAllProductOrders.go
+++ b/db/productOrder/getAllProductOrders.go
@@ -9,7 +9,7 @@ import (
 func GetAllProductOrders() ([]dtos.ProductOrderResponse, error) {
 	dbc := db.GetDB()
 	var orders []models.ProductOrder
-	err := dbc.Preload("Products").Find(&orders).Error
+	err := dbc.Preload("Products").Where("status != ?", "deleted").Find(&orders).Error
 	if err != nil {
 		return nil, err
 	}
@@ -18,12 +18,16 @@ func GetAllProductOrders() ([]dtos.ProductOrderResponse, error) {
 	for _, o := range orders {
 		var items []dtos.ProductOrderItemResponse
 		for _, p := range o.Products {
+			status := p.Status
+			if status == "" || status == "pendiente" {
+				status = "pending"
+			}
 			items = append(items, dtos.ProductOrderItemResponse{
 				ID:                   p.ID,
 				ProductTitle:         p.ProductTitle,
 				ProductCategoryTitle: p.ProductCategoryTitle,
 				Cant:                 p.Cant,
-				Status:               p.Status,
+				Status:               status,
 			})
 		}
 		result = append(result, dtos.ProductOrderResponse{

--- a/db/productOrder/getProductOrdersByDate.go
+++ b/db/productOrder/getProductOrdersByDate.go
@@ -10,7 +10,7 @@ import (
 func GetProductOrdersByDate(date time.Time) ([]dtos.ProductOrderResponse, error) {
 	dbc := db.GetDB()
 	var orders []models.ProductOrder
-	err := dbc.Preload("Products").Where("DATE(date) = DATE(?)", date).Find(&orders).Error
+	err := dbc.Preload("Products").Where("DATE(date) = DATE(?) AND status != ?", date, "deleted").Find(&orders).Error
 	if err != nil {
 		return nil, err
 	}
@@ -19,12 +19,16 @@ func GetProductOrdersByDate(date time.Time) ([]dtos.ProductOrderResponse, error)
 	for _, o := range orders {
 		var items []dtos.ProductOrderItemResponse
 		for _, p := range o.Products {
+			status := p.Status
+			if status == "" || status == "pendiente" {
+				status = "pending"
+			}
 			items = append(items, dtos.ProductOrderItemResponse{
 				ID:                   p.ID,
 				ProductTitle:         p.ProductTitle,
 				ProductCategoryTitle: p.ProductCategoryTitle,
 				Cant:                 p.Cant,
-				Status:               p.Status,
+				Status:               status,
 			})
 		}
 		result = append(result, dtos.ProductOrderResponse{

--- a/handlers/productOrder/deleteProductOrder.go
+++ b/handlers/productOrder/deleteProductOrder.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	db "viandasApp/db/productOrder"
+)
+
+func DeleteProductOrder(rw http.ResponseWriter, r *http.Request) {
+	ID := r.URL.Query().Get("idProductOrder")
+	if len(ID) < 1 {
+		http.Error(rw, "debe enviar el parametro idProductOrder", http.StatusBadRequest)
+		return
+	}
+
+	id, _ := strconv.Atoi(ID)
+	ok, err := db.DeleteProductOrder(id)
+	if err != nil || !ok {
+		http.Error(rw, "No se pudo eliminar la orden de productos", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusCreated)
+}

--- a/handlers/productOrder/updateProductOrderStatus.go
+++ b/handlers/productOrder/updateProductOrderStatus.go
@@ -14,8 +14,8 @@ func UpdateProductOrderStatus(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, "debe enviar el parametro idProductOrderItem", http.StatusBadRequest)
 		return
 	}
-	if status != "pendiente" && status != "entregado" {
-		http.Error(rw, "status debe ser 'pendiente' o 'entregado'", http.StatusBadRequest)
+	if status != "pending" && status != "entregado" {
+		http.Error(rw, "status debe ser 'pending' o 'entregado'", http.StatusBadRequest)
 		return
 	}
 

--- a/handlers/productOrder/uploadProductOrders.go
+++ b/handlers/productOrder/uploadProductOrders.go
@@ -21,6 +21,7 @@ func UploadProductOrder(rw http.ResponseWriter, r *http.Request) {
 			ProductTitle:         p.ProductTitle,
 			ProductCategoryTitle: p.ProductCategoryTitle,
 			Cant:                 p.Cant,
+			Status:               "pending",
 		})
 	}
 
@@ -28,7 +29,7 @@ func UploadProductOrder(rw http.ResponseWriter, r *http.Request) {
 		ClientName:     req.ClientName,
 		ClientLastName: req.ClientLastName,
 		Date:           req.Date,
-		Status:         req.Status,
+		Status:         "pending",
 		Products:       items,
 	}
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -142,6 +142,7 @@ func Routes(publicDir string) {
 	router.HandleFunc("/app/productOrder/getProductOrdersByDate", middlew.CheckDB(middlew.ValidateJWTAdmin(productOrder.GetProductOrdersByDate))).Methods("GET")
 	router.HandleFunc("/app/productOrder/addProductOrder", middlew.CheckDB(productOrder.UploadProductOrder)).Methods("POST")
 	router.HandleFunc("/app/productOrder/updateOrderItemStatus", middlew.CheckDB(middlew.ValidateJWTAdmin(productOrder.UpdateProductOrderStatus))).Methods("GET")
+	router.HandleFunc("/app/productOrder/deleteProductOrder", middlew.CheckDB(middlew.ValidateJWTAdmin(productOrder.DeleteProductOrder))).Methods("DELETE")
 
 	router.HandleFunc("/app/setting/addDiscount", middlew.CheckDB(middlew.ValidateJWTAdmin(setting.UploadDiscount))).Methods("POST")
 	router.HandleFunc("/app/setting/getDiscount", middlew.CheckDB(middlew.ValidateJWTAdmin(setting.GetAllDiscount))).Methods("GET")


### PR DESCRIPTION
- Nuevo endpoint DELETE /productOrder/deleteProductOrder (soft delete: status='deleted')
- Pedidos eliminados excluidos de todas las queries
- Items creados con status='pending'; retrocompat para '' y 'pendiente' existentes en DB
- Filtro pendientes corregido (usaba every, ahora some para items con status='pending')